### PR TITLE
Add github action to manage project board issues

### DIFF
--- a/.github/workflows/add-new-issues.yml
+++ b/.github/workflows/add-new-issues.yml
@@ -1,0 +1,16 @@
+name: Add New Issues
+on:
+    issues:
+        types:
+            - opened
+            - unassigned
+            - reopened
+jobs:
+    add-new-card:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: alex-page/github-project-automation-plus@5bcba1c1c091a222584d10913e5c060d32c44044
+              with:
+                  project: Bytesurfers Tasks
+                  column: To Do
+                  repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/move-assigned-issues.yml
+++ b/.github/workflows/move-assigned-issues.yml
@@ -1,0 +1,14 @@
+name: Move Assigned Issues
+on:
+    issues:
+        types:
+            - assigned
+jobs:
+    move-assigned-card:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: alex-page/github-project-automation-plus@5bcba1c1c091a222584d10913e5c060d32c44044
+              with:
+                  project: Bytesurfers Tasks
+                  column: Staged
+                  repo-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds a github action to automatically move issues once they are assigned and add issues when they are opened, unassigned or reopened, fixing #17.