### PR TITLE
Add player and enemy sprites

### DIFF
--- a/Assets/Resources/Enemy.prefab
+++ b/Assets/Resources/Enemy.prefab
@@ -93,8 +93,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9027714350541001172}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 6, z: 0}
-  m_LocalScale: {x: 0.95, y: 0.95, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 9027714349123552496}
   m_Father: {fileID: 0}
@@ -140,9 +140,9 @@ SpriteRenderer:
   m_SortingLayerID: 1036530043
   m_SortingLayer: 2
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: ebe73ca9363db456bacf42c025bb4847,
+  m_Sprite: {fileID: 8733842730735159489, guid: 0246d79ac60b897b6836ef7b5186b0c7,
     type: 3}
-  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -164,7 +164,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 1
-  m_Mass: 0.7853982
+  m_Mass: 0.5541769
   m_LinearDrag: 0
   m_AngularDrag: 0
   m_GravityScale: 0
@@ -188,7 +188,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.42
 --- !u!114 &9027714350541001168
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Player.prefab
+++ b/Assets/Resources/Player.prefab
@@ -116,7 +116,7 @@ Transform:
   m_GameObject: {fileID: 5676611098347806923}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.95, y: 0.95, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4693431101948605444}
   - {fileID: 4693431101761815406}
@@ -135,7 +135,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 1
-  m_Mass: 0.7853982
+  m_Mass: 0.5541769
   m_LinearDrag: 0
   m_AngularDrag: 0
   m_GravityScale: 0
@@ -159,7 +159,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.42
 --- !u!114 &2475852923928295786
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -406,9 +406,9 @@ SpriteRenderer:
   m_SortingLayerID: 1036530043
   m_SortingLayer: 2
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: ebe73ca9363db456bacf42c025bb4847,
+  m_Sprite: {fileID: -6121086664708760571, guid: 0246d79ac60b897b6836ef7b5186b0c7,
     type: 3}
-  m_Color: {r: 0.49803922, g: 0.49803922, b: 0.49803922, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -10896,12 +10896,12 @@ PrefabInstance:
     - target: {fileID: 9027714350541001174, guid: 7d178d64c618d137f9c5f4bd28cc9c2b,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.95
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9027714350541001174, guid: 7d178d64c618d137f9c5f4bd28cc9c2b,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.95
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 9027714350541001174, guid: 7d178d64c618d137f9c5f4bd28cc9c2b,
         type: 3}

--- a/Assets/Scripts/Enemy/ChaserAI.cs
+++ b/Assets/Scripts/Enemy/ChaserAI.cs
@@ -17,7 +17,9 @@ namespace Enemy
 
         private void FixedUpdate()
         {
-            _rigidbody2D.velocity = _playerDetector.GetTrackingPlayerDirection() * movementSpeed;
+            Vector2 direction = _playerDetector.GetTrackingPlayerDirection();
+            _rigidbody2D.velocity = direction * movementSpeed;
+            transform.rotation = Quaternion.Euler(0, 0, Utils.Vector2ToDeg(direction));
         }
     }
 }

--- a/Assets/Sprites/player-and-enemies.png
+++ b/Assets/Sprites/player-and-enemies.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84a45bbe99fa11ba2e937792cd3804bbf26c86c5bb2c2a4ad5daf4c11f085077
+size 8011

--- a/Assets/Sprites/player-and-enemies.png.meta
+++ b/Assets/Sprites/player-and-enemies.png.meta
@@ -1,0 +1,180 @@
+fileFormatVersion: 2
+guid: 0246d79ac60b897b6836ef7b5186b0c7
+TextureImporter:
+  internalIDToNameTable:
+  - first:
+      213: -6121086664708760571
+    second: player-and-enemies_0
+  - first:
+      213: 8733842730735159489
+    second: player-and-enemies_1
+  - first:
+      213: 1863022367390955774
+    second: player-and-enemies_2
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: player-and-enemies_0
+      rect:
+        serializedVersion: 2
+        x: 22
+        y: 150
+        width: 84
+        height: 84
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 50c57aefb188d0ba0800000000000000
+      internalID: -6121086664708760571
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: player-and-enemies_1
+      rect:
+        serializedVersion: 2
+        x: 25
+        y: 19
+        width: 91
+        height: 84
+      alignment: 9
+      pivot: {x: 0.464, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 1c8c89190b7d43970800000000000000
+      internalID: 8733842730735159489
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: player-and-enemies_2
+      rect:
+        serializedVersion: 2
+        x: 153
+        y: 18
+        width: 92
+        height: 85
+      alignment: 9
+      pivot: {x: 0.464, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: ef8f1f0f8f8cad910800000000000000
+      internalID: 1863022367390955774
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/player-and-enemies.svg
+++ b/Assets/Sprites/player-and-enemies.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3e1d074dde6bfe9138ca981b3833e0b926c226cedf319ccff19992c65f615f3
+size 3199

--- a/Assets/Sprites/player-and-enemies.svg.meta
+++ b/Assets/Sprites/player-and-enemies.svg.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0df551e3ea39c7c44bd2cd80af7a0bf2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR fixes #54 by adding a player and enemy sprite into the game. Another enemy sprite is also included for further expansion.

This also edits the enemy script to make them face towards the player.