### PR TITLE
Fix enemy tracking

### DIFF
--- a/Assets/Scripts/Enemy/ChaserAI.cs
+++ b/Assets/Scripts/Enemy/ChaserAI.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Enemy
@@ -18,6 +19,7 @@ namespace Enemy
         private void FixedUpdate()
         {
             Vector2 direction = _playerDetector.GetTrackingPlayerDirection();
+            Debug.Log(direction);
             _rigidbody2D.velocity = direction * movementSpeed;
             float angle = Utils.Vector2ToDeg(direction);
             transform.rotation = Quaternion.AngleAxis(angle, Vector3.forward);

--- a/Assets/Scripts/Enemy/PlayerDetector.cs
+++ b/Assets/Scripts/Enemy/PlayerDetector.cs
@@ -10,10 +10,10 @@ namespace Enemy
         [SerializeField] private float updatePeriod;
         
         private Transform _trackingPlayer;
-        private readonly List<Transform> _players;
+        private List<Transform> _players;
         private float _updateCooldown;
 
-        private PlayerDetector()
+        private void Awake()
         {
             _players = new List<Transform>();
         }
@@ -47,6 +47,8 @@ namespace Enemy
                 minDistance = playerDistance;
                 _trackingPlayer = player;
             }
+
+            _updateCooldown = updatePeriod;
         }
 
         private void RemovePlayer(Transform other)
@@ -69,11 +71,15 @@ namespace Enemy
         
         private void OnTriggerEnter2D(Collider2D other)
         {
+            if (!other.CompareTag("Player")) return;
+            
             AddPlayer(other.transform);
         }
 
         private void OnTriggerExit2D(Collider2D other)
         {
+            if (!other.CompareTag("Player")) return;
+            
             RemovePlayer(other.transform);
         }
     }


### PR DESCRIPTION
Fixes #83. Turns out we weren't checking if the collider was a player before adding it to the list.